### PR TITLE
WKT and binary fixes

### DIFF
--- a/src/Microsoft.SqlServer.Types.Tests/Geometry/DeserializeFromBinary.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geometry/DeserializeFromBinary.cs
@@ -82,6 +82,23 @@ namespace Microsoft.SqlServer.Types.Tests.Geometry
         }
 
         [TestMethod]
+        public void TestEmptyGeometryCollection()
+        {
+            var coll = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x04,
+                0, //vertices
+                0, //figures
+                1, -1, -1, (byte)0x07 //shapes
+            );
+            var g = Microsoft.SqlServer.Types.SqlGeometry.Deserialize(new System.Data.SqlTypes.SqlBytes(coll));
+            Assert.IsFalse(g.IsNull);
+            Assert.AreEqual("GeometryCollection", g.STGeometryType().Value);
+            Assert.AreEqual(4326, g.STSrid.Value);
+            Assert.IsTrue(g.STX.IsNull);
+            Assert.IsTrue(g.STY.IsNull);
+            Assert.AreEqual(0, g.STNumGeometries());
+        }
+
+        [TestMethod]
         public void TestGeometryCollection()
         {
             var coll = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x04,

--- a/src/Microsoft.SqlServer.Types.Tests/Geometry/SerializeToBinary.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geometry/SerializeToBinary.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlTypes;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.SqlServer.Types.Tests.Geometry
+{
+    [TestClass]
+    [TestCategory("SqlGeometry")]
+    public class SerializeToBinary
+    {
+        [TestMethod]
+        public void TestEmptyPoint()
+        {
+            var emptyPoint = StreamExtensions.CreateBytes(0, (byte)0x01, (byte)0x04, 0, 0, 1, -1, -1, (byte)0x01);
+
+            var g = SqlGeometry.Parse("POINT EMPTY");
+
+            var serialized = g.Serialize().Value;
+            CollectionAssert.AreEqual(emptyPoint, serialized);
+        }
+
+        [TestMethod]
+        public void TestPoint()
+        {
+            var point = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x0C, 5d, 10d);
+            var g = SqlGeometry.Parse("POINT (5 10)");
+            g.STSrid = 4326;
+
+            var serialized = g.Serialize().Value;
+            CollectionAssert.AreEqual(point, serialized);
+        }
+
+        [TestMethod]
+        public void TestLineString()
+        {
+            var line = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x05,
+                3, 0d, 1d, 3d, 2d, 4d, 5d, 1d, 2d, double.NaN, //vertices
+                1, (byte)0x01, 0, //figures
+                1, -1, 0, (byte)0x02 //shapes
+                );
+            var g = SqlGeometry.Parse("LINESTRING (0 1 1, 3 2 2, 4 5 NaN)");
+            g.STSrid = 4326;
+
+            var serialized = g.Serialize().Value;
+            CollectionAssert.AreEqual(line, serialized);
+        }
+
+        [TestMethod]
+        public void TestEmptyGeometryCollection()
+        {
+            var coll = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x04,
+                0, //vertices
+                0, //figures
+                1, -1, -1, (byte)0x07 //shapes
+            );
+
+            var g = SqlGeometry.Parse("GEOMETRYCOLLECTION EMPTY");
+            g.STSrid = 4326;
+
+            var serialized = g.Serialize().Value;
+            CollectionAssert.AreEqual(coll, serialized);
+        }
+
+        //[TestMethod]
+        public void TestGeometryCollectionWithEmpty()
+        {
+            var coll = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x04,
+                1, 4d, 6d, //vertices
+                1, (byte)0x01, 0, //figures
+                3, -1, 0, (byte)0x07, 0, 0, (byte)0x00, 0, -1, (byte)0x01 //shapes
+            );
+
+            var g = SqlGeometry.Parse("GEOMETRYCOLLECTION(POINT(4 6), POINT EMPTY)");
+            g.STSrid = 4326;
+
+            var serialized = g.Serialize().Value;
+            CollectionAssert.AreEqual(coll, serialized);
+        }
+    }
+}

--- a/src/Microsoft.SqlServer.Types.Tests/Geometry/SerializeToBinary.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geometry/SerializeToBinary.cs
@@ -64,7 +64,9 @@ namespace Microsoft.SqlServer.Types.Tests.Geometry
             CollectionAssert.AreEqual(coll, serialized);
         }
 
-        //[TestMethod]
+        [TestMethod]
+        [Ignore]
+        [WorkItem(25)]
         public void TestGeometryCollectionWithEmpty()
         {
             var coll = StreamExtensions.CreateBytes(4326, (byte)0x01, (byte)0x04,

--- a/src/Microsoft.SqlServer.Types/ShapeData.cs
+++ b/src/Microsoft.SqlServer.Types/ShapeData.cs
@@ -128,7 +128,7 @@ namespace Microsoft.SqlServer.Types
             this._vertices = points;
             this._figures = figures;
             this._shapes = shapes;
-            this._isValid = false;
+            this._isValid = true;
             this._isLargerThanAHemisphere = false;
             _zValues = null;
             _mValues = null;
@@ -143,7 +143,7 @@ namespace Microsoft.SqlServer.Types
             this._figures = figures;
             this._shapes = shapes;
             this._segments = mSegments;
-            this._isValid = false;
+            this._isValid = true;
             this._isLargerThanAHemisphere = false;
         }
 
@@ -372,12 +372,13 @@ namespace Microsoft.SqlServer.Types
 
             if (!props.HasFlag(SerializationProps.IsSingleLineSegment) &&
                 !props.HasFlag(SerializationProps.IsSinglePoint))
-                bw.Write(NumPoints); // Number of Points = 0 (no points) 
-            foreach (var p in _vertices)
-            {
-                bw.Write(p.X); //X
-                bw.Write(p.Y); //Y
-            }
+                bw.Write(NumPoints); // Number of Points = 0 (no points)
+            if (_vertices != null)
+                foreach (var p in _vertices)
+                {
+                    bw.Write(p.X); //X
+                    bw.Write(p.Y); //Y
+                }
             if (_zValues != null)
                 foreach (var z in _zValues)
                 {

--- a/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
+++ b/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
@@ -112,7 +112,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.Point, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.Point, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             _shapes.Add(new Shape() { type = OGCGeometryType.Point, FigureOffset = _figures.Count, ParentOffset = parentOffset });
@@ -126,7 +126,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.MultiPoint, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.MultiPoint, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             int index = _shapes.Count;
@@ -158,7 +158,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.LineString, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.LineString, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             else
@@ -172,7 +172,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.MultiLineString, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.MultiLineString, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             ReadToken(PARAN_START);
@@ -192,7 +192,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.Polygon, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.Polygon, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             _shapes.Add(new Shape() { type = OGCGeometryType.Polygon, FigureOffset = _figures.Count, ParentOffset = parentOffset });
@@ -216,7 +216,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.MultiPolygon, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.MultiPolygon, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
 
@@ -252,7 +252,7 @@ namespace Microsoft.SqlServer.Types.Wkt
         {
             if (ReadOptionalEmptyToken())
             {
-                _shapes.Add(new Shape() { type = OGCGeometryType.GeometryCollection, FigureOffset = _figures.Count, ParentOffset = parentOffset });
+                _shapes.Add(new Shape() { type = OGCGeometryType.GeometryCollection, FigureOffset = -1, ParentOffset = parentOffset });
                 return;
             }
             int index = _shapes.Count;


### PR DESCRIPTION
Some fixes for the conversion from WKT and into binary.

I also added a currently disabled test TestGeometryCollectionWithEmpty which would otherwise fail because of an incorrect implementation of the FigureAttributes.
The current implementation mixes V1 and V2. Sometimes on creation V1 attributes are used and in other places V2 are used. Should I open a bug? Or maybe if you tell me what your idea was I could try to clean it up. 