### PR TITLE
Populate method for IGeometrySink110 and IGeographySink110

### DIFF
--- a/src/Microsoft.SqlServer.Types.RefTests/Microsoft.SqlServer.Types.RefTests.csproj
+++ b/src/Microsoft.SqlServer.Types.RefTests/Microsoft.SqlServer.Types.RefTests.csproj
@@ -49,6 +49,9 @@
     <Compile Include="..\Microsoft.SqlServer.Types.Tests\AssemblyLoader.cs">
       <Link>AssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.SqlServer.Types.Tests\Geography\SqlGeographyBuilderTests.cs">
+      <Link>Geography\SqlGeographyBuilderTests.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.SqlServer.Types.Tests\Geography\WktTests.cs">
       <Link>Geography\WktTests.cs</Link>
     </Compile>

--- a/src/Microsoft.SqlServer.Types.Tests/Geography/SqlGeographyBuilderTests.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geography/SqlGeographyBuilderTests.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using Microsoft.SqlServer.Types.Tests.Geometry;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.SqlServer.Types.Tests.Geography
+{
+    [TestClass]
+    [TestCategory("SqlGeography")]
+    [TestCategory("Sink")]
+    public class SqlGeographyBuilderTests
+    {
+        [TestMethod]
+        public void CreateEmpty()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.BeginGeography(OpenGisGeographyType.Point);
+            b.EndGeography();
+            var g = b.ConstructedGeography;
+            Assert.IsTrue(g.STIsEmpty().Value);
+        }
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void CreateEmptyNoSrid()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            var g = b.ConstructedGeography;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void GetConstructedBeforeCompletion()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            var g = b.ConstructedGeography;
+            Assert.IsTrue(g.STIsEmpty().Value);
+        }
+
+        [TestMethod]
+        public void BuildPoint()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.BeginGeography(OpenGisGeographyType.Point);
+            b.BeginFigure(1, 2);
+            b.EndFigure();
+            b.EndGeography();
+            var g = b.ConstructedGeography;
+            Assert.AreEqual("Point", g.STGeometryType());
+            Assert.AreEqual(2, g.Long);
+            Assert.AreEqual(1, g.Lat);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void EndGeographyBeforeBeginGeography()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.EndGeography();
+            var g = b.ConstructedGeography;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void BeginFigureBeforeBeginGeography()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.BeginFigure(1, 2);
+            var g = b.ConstructedGeography;
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void EndFigureBeforeBeginFigure()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.BeginGeography(OpenGisGeographyType.Point);
+            b.EndFigure();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void BuildPoint_NoSrid()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.BeginGeography(OpenGisGeographyType.Point); // Should throw format exception
+        }
+
+        [TestMethod]
+        public void BuildLineString()
+        {
+            SqlGeographyBuilder b = new SqlGeographyBuilder();
+            b.SetSrid(4326);
+            b.BeginGeography(OpenGisGeographyType.LineString);
+            b.BeginFigure(1, 2);
+            b.AddLine(3, 4, 10, null);
+            b.AddLine(6, 7, 11, 12);
+            b.EndFigure();
+            b.EndGeography();
+            var g = b.ConstructedGeography;
+            Assert.AreEqual("LineString", g.STGeometryType());
+            Assert.AreEqual(3, g.STNumPoints());
+            Assert.AreEqual(1, g.STStartPoint().Lat);
+            Assert.AreEqual(2, g.STStartPoint().Long);
+            Assert.AreEqual(6, g.STEndPoint().Lat);
+            Assert.AreEqual(7, g.STEndPoint().Long);
+            Assert.AreEqual(3, g.STPointN(2).Lat);
+            Assert.AreEqual(4, g.STPointN(2).Long);
+            Assert.IsTrue(g.STPointN(2).HasZ);
+            Assert.IsFalse(g.STPointN(2).HasM);
+        }
+    }
+}

--- a/src/Microsoft.SqlServer.Types/ShapeData.cs
+++ b/src/Microsoft.SqlServer.Types/ShapeData.cs
@@ -211,7 +211,7 @@ namespace Microsoft.SqlServer.Types
         public ShapeData GetRing(int index) => AsRing(index);
         public bool HasZ => _zValues != null;
         public bool HasM => _mValues != null;
-        public bool IsEmpty => !(_vertices != null && _vertices.Length > 0 || _shapes[0].type == OGCGeometryType.FullGlobe);
+        public bool IsEmpty => !(_vertices != null && _vertices.Length > 0 || _shapes.Length > 0 && _shapes[0].type == OGCGeometryType.FullGlobe);
 
         public ShapeData GetGeometryN(int index)
         {

--- a/src/Microsoft.SqlServer.Types/ShapeDataBuilder.cs
+++ b/src/Microsoft.SqlServer.Types/ShapeDataBuilder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.SqlServer.Types
         private ShapeDataBuilder.State _state;
         private Stack<Operation> operationStack = new Stack<Operation>();
         private Operation CurrentOperation => operationStack.Count > 0 ? operationStack.Peek() : Operation.None;
-        public string GeoType { get; set; } = "Geometry";
+        internal string GeoType { get; set; } = "Geometry";
 
         public ShapeData ConstructedShapeData
         {

--- a/src/Microsoft.SqlServer.Types/ShapeDataBuilder.cs
+++ b/src/Microsoft.SqlServer.Types/ShapeDataBuilder.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace Microsoft.SqlServer.Types
 {
@@ -19,12 +21,16 @@ namespace Microsoft.SqlServer.Types
         private readonly bool _ignoreZM;
         private FigureAttributes _nextFigureAttribute;
         private ShapeDataBuilder.State _state;
+        private Stack<Operation> operationStack = new Stack<Operation>();
+        private Operation CurrentOperation => operationStack.Count > 0 ? operationStack.Peek() : Operation.None;
+        public string GeoType { get; set; } = "Geometry";
 
         public ShapeData ConstructedShapeData
         {
             get
             {
-                _state = State.End;
+                if (_shapes.Count == 0)
+                    throw new FormatException($"24300: Expected a call to Begin{GeoType}, but Finish was called.");
                 if (_vertices.Count <= 0)
                 {
                     return new ShapeData(null, null, _shapes.ToArray());
@@ -67,15 +73,24 @@ namespace Microsoft.SqlServer.Types
             }
             _parents.Push(_shapes.Count);
             _shapes.Add(shape);
+            operationStack.Push(Operation.Geo);
         }
 
         public void EndGeo()
         {
+            if (CurrentOperation == Operation.Figure)
+                EndFigure();
+            if(CurrentOperation != Operation.Geo)
+                throw new FormatException($"24300: Expected a call to Begin{GeoType}, but End{GeoType} was called.");
+            operationStack.Pop();
             _parents.Pop();
         }
 
         public void BeginFigure()
         {
+            if (CurrentOperation != Operation.Geo)
+                throw new FormatException($"24300: Expected a call to Begin{GeoType}, but BeginFigure was called.");
+
             FigureAttributes nextFigureAttribute = FigureAttributes.Line;
             var shapeType = _shapes[_shapes.Count - 1].type;
             if (shapeType == OGCGeometryType.CircularString)
@@ -108,10 +123,15 @@ namespace Microsoft.SqlServer.Types
                 _state = State.Segment;
             }
             _figures.Add(figure);
+            operationStack.Push(Operation.Figure);
         }
 
         public void EndFigure()
         {
+            if (CurrentOperation != Operation.Figure)
+                throw new FormatException($"24301: Expected a call to BeginFigure or End{GeoType}, but EndFigure was called.");
+
+            operationStack.Pop();
             UpdateFigureOffsets(_figures.Count - 1, _shapes.Count - 1);
             if (_shapes[_shapes.Count - 1].type == OGCGeometryType.Polygon)
             {
@@ -137,7 +157,11 @@ namespace Microsoft.SqlServer.Types
 
         public void AddLine(double x, double y, double? z, double? m)
         {
-            //TODO: Handle curves
+            if (CurrentOperation != Operation.Figure)
+                throw new FormatException($"24301: Expected a call to BeginFigure or End{GeoType}, but AddLine was called.");
+            if (_shapes.Last().type == OGCGeometryType.Point)
+                throw new FormatException("24300: Expected a call to EndFigure, but AddLine was called.");
+           
             AddPoint(x, y, z, m);
         }
 
@@ -168,12 +192,20 @@ namespace Microsoft.SqlServer.Types
             }
         }
 
-        private enum State
+        private enum State : int
         {
-            Start,
-            Figure,
-            Segment,
-            End
+            Start = 0,
+            Figure = 1,
+            Segment = 2,
+            End = 3,
+        }
+
+        private enum Operation : int
+        {
+            None = 0,
+            Geo = 1,
+            Figure = 2,
+            Segment = 3,
         }
 
         private enum SegmentType : byte

--- a/src/Microsoft.SqlServer.Types/SqlGeographyBuilder.cs
+++ b/src/Microsoft.SqlServer.Types/SqlGeographyBuilder.cs
@@ -8,16 +8,29 @@ namespace Microsoft.SqlServer.Types
     public class SqlGeographyBuilder : IGeographySink110
     {
         private readonly ShapeDataBuilder _builder;
-        private int _srid = 4326;
+        private int _srid = -1;
 
         public SqlGeographyBuilder()
         {
             _builder = new ShapeDataBuilder();
         }
 
-        public virtual SqlGeography ConstructedGeography => new SqlGeography(_builder.ConstructedShapeData, _srid);
+        public virtual SqlGeography ConstructedGeography
+        {
+            get
+            {
+                if (_srid < 0)
+                    throw new FormatException($"System.FormatException: 24300: Expected a call to SetSrid, but Finish was called.");
+                return new SqlGeography(_builder.ConstructedShapeData, _srid);
+            }
+        }
 
-        public virtual void BeginGeography(OpenGisGeographyType type) => _builder.BeginGeo((OGCGeometryType)type);
+        public virtual void BeginGeography(OpenGisGeographyType type)
+        {
+            if (_srid < 0)
+                throw new FormatException($"System.FormatException: 24300: Expected a call to SetSrid, but BeginGeography({type}) was called.");
+            _builder.BeginGeo((OGCGeometryType)type);
+        }
 
         public void BeginFigure(double latitude, double longitude) => BeginFigure(latitude, longitude, null, null);
 

--- a/src/Microsoft.SqlServer.Types/SqlGeographyBuilder.cs
+++ b/src/Microsoft.SqlServer.Types/SqlGeographyBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.SqlServer.Types
 
         public SqlGeographyBuilder()
         {
-            _builder = new ShapeDataBuilder();
+            _builder = new ShapeDataBuilder() { GeoType = "Geography" };
         }
 
         public virtual SqlGeography ConstructedGeography
@@ -20,7 +20,7 @@ namespace Microsoft.SqlServer.Types
             get
             {
                 if (_srid < 0)
-                    throw new FormatException($"System.FormatException: 24300: Expected a call to SetSrid, but Finish was called.");
+                    throw new FormatException($"24300: Expected a call to SetSrid, but Finish was called.");
                 return new SqlGeography(_builder.ConstructedShapeData, _srid);
             }
         }
@@ -28,7 +28,7 @@ namespace Microsoft.SqlServer.Types
         public virtual void BeginGeography(OpenGisGeographyType type)
         {
             if (_srid < 0)
-                throw new FormatException($"System.FormatException: 24300: Expected a call to SetSrid, but BeginGeography({type}) was called.");
+                throw new FormatException($"24300: Expected a call to SetSrid, but BeginGeography({type}) was called.");
             _builder.BeginGeo((OGCGeometryType)type);
         }
 
@@ -36,6 +36,8 @@ namespace Microsoft.SqlServer.Types
 
         public virtual void BeginFigure(double latitude, double longitude, double? z, double? m)
         {
+            if (_srid < 0)
+                throw new FormatException($"24300: Expected a call to SetSrid, but BeginFigure was called.");
             ValidateLatLon(latitude, longitude);
             _builder.BeginFigure();
             _builder.AddPoint(latitude, longitude, z, m);
@@ -46,7 +48,7 @@ namespace Microsoft.SqlServer.Types
         public virtual void AddLine(double latitude, double longitude, double? z, double? m)
         {
             ValidateLatLon(latitude, longitude);
-            _builder.AddPoint(latitude, longitude, z, m);
+            _builder.AddLine(latitude, longitude, z, m);
         }
 
         private void ValidateLatLon(double lat, double lon)


### PR DESCRIPTION
Implementation of the populate method for the IGeometrySink110 and IGeographySink110 interfaces. This is needed for this lib to be used as a replacement of the original Microsoft.SqlServer.Types.