### PR TITLE
Added support to read and write FULLGLOBE SqlGeography

### DIFF
--- a/src/Microsoft.SqlServer.Types.Tests/Geography/WktTests.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geography/WktTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.SqlServer.Types.Tests.Geometry;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Data.SqlTypes;
 
 namespace Microsoft.SqlServer.Types.Tests.Geography
 {
@@ -73,6 +74,24 @@ namespace Microsoft.SqlServer.Types.Tests.Geography
                     Assert.AreEqual("LINESTRING (-122.36 47.656, -122.343 47.656)", cmd.ExecuteScalar().ToString());
                 }
             }
+        }
+
+        [TestMethod]
+        public void CreateFullGlobe()
+        {
+            var wkt = "FULLGLOBE";
+            var value = SqlGeography.STGeomFromText(new SqlChars(new SqlString(wkt)), 4326);
+            Assert.IsNotNull(value);
+        }
+
+        [TestMethod]
+        public void FullGlobeWkt()
+        {
+            var wkt = "FULLGLOBE";
+            var value = SqlGeography.STGeomFromText(new SqlChars(new SqlString(wkt)), 4326);
+
+            var valueWkt = value.STAsText().ToSqlString().Value;
+            Assert.AreEqual(wkt, valueWkt);
         }
     }
 }

--- a/src/Microsoft.SqlServer.Types.Tests/Geography/WktTests.cs
+++ b/src/Microsoft.SqlServer.Types.Tests/Geography/WktTests.cs
@@ -93,5 +93,15 @@ namespace Microsoft.SqlServer.Types.Tests.Geography
             var valueWkt = value.STAsText().ToSqlString().Value;
             Assert.AreEqual(wkt, valueWkt);
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(System.FormatException))]
+        public void FailCollectionWithFullGlobe()
+        {
+            var wkt = "GEOMETRYCOLLECTION (POINT (40 10), LINESTRING (10 10, 20 20, 10 40), FULLGLOBE, POLYGON ((40 40, 20 45, 45 30, 40 40)))";
+            var value = SqlGeography.STGeomFromText(new SqlChars(new SqlString(wkt)), 4326);
+            var valueWkt = value.STAsText().ToSqlString().Value;
+            Assert.AreEqual(wkt, valueWkt);
+        }
     }
 }

--- a/src/Microsoft.SqlServer.Types/ShapeData.cs
+++ b/src/Microsoft.SqlServer.Types/ShapeData.cs
@@ -147,6 +147,8 @@ namespace Microsoft.SqlServer.Types
             this._isLargerThanAHemisphere = false;
         }
 
+        public Shape[] Shapes => _shapes;
+
         public PointZM GetPointN(int index)
         {
             Point p = _vertices[index - 1];

--- a/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
+++ b/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
@@ -75,6 +75,8 @@ namespace Microsoft.SqlServer.Types.Wkt
                 ReadMultiPolygon(parentOffset);
             else if (nextToken.Length == 18) //"GEOMETRYCOLLECTION"
                 ReadGeometryCollection(parentOffset);
+            else if (nextToken.Length == 9) //"FULLGLOBE"
+                ReadFullGlobe(parentOffset);
             else
                 throw new FormatException("Invalid Well-known Text");
             //switch (Encoding.UTF8.GetString(nextToken))
@@ -264,6 +266,11 @@ namespace Microsoft.SqlServer.Types.Wkt
             }
             while (ReadOptionalChar(COMMA));
             ReadToken(PARAN_END);
+        }
+
+        private void ReadFullGlobe(int parentOffset = -1)
+        {
+            _shapes.Add(new Shape() { type = OGCGeometryType.FullGlobe, FigureOffset = -1, ParentOffset = parentOffset });
         }
 
         private void ReadCoordinateCollection()

--- a/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
+++ b/src/Microsoft.SqlServer.Types/Wkt/WktReader.cs
@@ -270,6 +270,8 @@ namespace Microsoft.SqlServer.Types.Wkt
 
         private void ReadFullGlobe(int parentOffset = -1)
         {
+            if(_shapes.Count > 0)
+                throw new FormatException("FullGlobe instances cannot be objects in the GeometryCollection. GeometryCollections can contain the following instances: Points, MultiPoints, LineStrings, MultiLineStrings, Polygons, MultiPolygons, CircularStrings, CompoundCurves, CurvePolygons and GeometryCollections.");
             _shapes.Add(new Shape() { type = OGCGeometryType.FullGlobe, FigureOffset = -1, ParentOffset = parentOffset });
         }
 

--- a/src/Microsoft.SqlServer.Types/Wkt/WktWriter.cs
+++ b/src/Microsoft.SqlServer.Types/Wkt/WktWriter.cs
@@ -41,6 +41,14 @@ namespace Microsoft.SqlServer.Types.Wkt
         private static void WriteGeometry(ShapeData geometry, StringBuilder sb, bool includeZ, bool includeM, CoordinateOrder order)
         {
             var type = geometry.Type;
+            
+            // Special handling for FULLGLOBE
+            if(type == OGCGeometryType.FullGlobe)
+            {
+                sb.Append("FULLGLOBE");
+                return;
+            }
+
             sb.Append(type.ToString().ToUpperInvariant());
             if (geometry.IsEmpty)
             {


### PR DESCRIPTION
If you wouldn't mind looking this over maybe it would add support for the "FULLGLOBE" SqlGeography?  I added tests to create and write the WKT back out.  I *think* the creation looks correct, but I'm not entirely sure how to compare the native output of a FULLGLOBE SqlGeographyto the equivalent SqlGeography from my output.