### PR TITLE
Change dll including to GeneratePathProperty

### DIFF
--- a/src/Microsoft.SqlServer.Types.Tests/Microsoft.SqlServer.Types.Tests.csproj
+++ b/src/Microsoft.SqlServer.Types.Tests/Microsoft.SqlServer.Types.Tests.csproj
@@ -14,11 +14,11 @@
     <Compile Include="..\Microsoft.SqlServer.Types\SqlHierarchy\KnownPatterns.cs" Link="HierarchyId\KnownPatterns.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="$(USERPROFILE)\.nuget\packages\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\x64\msvcr120.dll" Link="x64\msvcr120.dll" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(USERPROFILE)\.nuget\packages\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\x64\SqlServerSpatial140.dll" Link="x64\SqlServerSpatial140.dll" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(USERPROFILE)\.nuget\packages\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\x86\msvcr120.dll" Link="x86\msvcr120.dll" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="$(USERPROFILE)\.nuget\packages\microsoft.sqlserver.types\14.0.1016.290\nativeBinaries\x86\SqlServerSpatial140.dll" Link="x86\SqlServerSpatial140.dll" CopyToOutputDirectory="PreserveNewest" />
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
+    <Content Include="$(PkgMicrosoft_SqlServer_Types)\nativeBinaries\x64\msvcr120.dll" Link="x64\msvcr120.dll" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_SqlServer_Types)\nativeBinaries\x64\SqlServerSpatial140.dll" Link="x64\SqlServerSpatial140.dll" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_SqlServer_Types)\nativeBinaries\x86\msvcr120.dll" Link="x86\msvcr120.dll" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="$(PkgMicrosoft_SqlServer_Types)\nativeBinaries\x86\SqlServerSpatial140.dll" Link="x86\SqlServerSpatial140.dll" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\Microsoft.SqlServer.Types\Microsoft.SqlServer.Types.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net461'">
-    <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" />
+    <PackageReference Include="Microsoft.SqlServer.Types" Version="14.0.1016.290" GeneratePathProperty="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Remove hardcoded nuget path to generated one

Nuget global‑packages path can be changed and it's better to use `GeneratePathProperty`