### PR TITLE
Compare within IsDescendantOf if levels of HierarchyId are equal.

### DIFF
--- a/src/Microsoft.SqlServer.Types/SqlHierarchy/HierarhyId.cs
+++ b/src/Microsoft.SqlServer.Types/SqlHierarchy/HierarhyId.cs
@@ -222,7 +222,7 @@ namespace Microsoft.SqlServer.Types.SqlHierarchy
         /// <param name="parent">parent</param>
         public bool IsDescendantOf(HierarchyId parent)
         {
-            if (parent.GetLevel() > GetLevel())
+            if (parent.GetLevel() >= GetLevel())
             {
                 return false;
             }


### PR DESCRIPTION
I think if two HierachyId are on the same level that one cannot be parent for another